### PR TITLE
Eliminate warnings on G++12

### DIFF
--- a/foxxll/io/request_queue_impl_1q.cpp
+++ b/foxxll/io/request_queue_impl_1q.cpp
@@ -34,7 +34,6 @@
 namespace foxxll {
 
 struct file_offset_match
-    : public std::binary_function<request_ptr, request_ptr, bool>
 {
     bool operator () (
         const request_ptr& a,

--- a/foxxll/io/request_queue_impl_qwqr.cpp
+++ b/foxxll/io/request_queue_impl_qwqr.cpp
@@ -34,7 +34,6 @@ namespace foxxll {
 
 
 struct file_offset_match
-    : public std::binary_function<request_ptr, request_ptr, bool>
 {
     bool operator () (
         const request_ptr& a,

--- a/foxxll/mng/async_schedule.cpp
+++ b/foxxll/mng/async_schedule.cpp
@@ -43,7 +43,7 @@ struct sim_event
     inline sim_event(size_t t, size_t b) : timestamp(t), iblock(b) { }
 };
 
-struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
+struct sim_event_cmp
 {
     inline bool operator () (const sim_event& a, const sim_event& b) const
     {
@@ -52,7 +52,7 @@ struct sim_event_cmp : public std::binary_function<sim_event, sim_event, bool>
 };
 
 using write_time_pair = std::pair<size_t, size_t>;
-struct write_time_cmp : public std::binary_function<write_time_pair, write_time_pair, bool>
+struct write_time_cmp
 {
     inline bool operator () (const write_time_pair& a, const write_time_pair& b) const
     {


### PR DESCRIPTION
Removed usages of `std::binary_function` which is not needed anymore and was removed from the C++ standard.